### PR TITLE
feat: allow psr logger v2 and v3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "psr/event-dispatcher": "^1.0",
         "psr/http-factory": "^1.0",
         "psr/http-server-handler": "^1.0",
-        "psr/log": "^1.1",
+        "psr/log": "^1.1|^2.0|^3.0",
         "psr/simple-cache": "^1.0",
         "ramsey/uuid": "^4.1"
     },


### PR DESCRIPTION
Hi!

I wanted to give your implementation a go, but I'm on psr/logger v3, so this PR is to allow v2 and v3 as well. Not sure if more is needed, but tests passed locally (on php 8.1) and also on CI.