### PR TITLE
feat: allow psr simple-cache v2 and v3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "psr/http-factory": "^1.0",
         "psr/http-server-handler": "^1.0",
         "psr/log": "^1.1",
-        "psr/simple-cache": "^1.0|^2",
+        "psr/simple-cache": "^1.0|^2.0|^3.0",
         "ramsey/uuid": "^4.1"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "psr/http-factory": "^1.0",
         "psr/http-server-handler": "^1.0",
         "psr/log": "^1.1",
-        "psr/simple-cache": "^1.0",
+        "psr/simple-cache": "^1.0|^2",
         "ramsey/uuid": "^4.1"
     },
     "require-dev": {


### PR DESCRIPTION
Hi!

Similar to https://github.com/SpazzMarticus/TusServer/pull/5; I wanted to give your implementation a go, but I'm on psr/simple-cache v3, so this PR is to allow v2 and v3 as well. Not sure if more is needed, but tests passed locally (on php 8.1) and also on CI.