### PR TITLE
feat: use an abstract filesystem

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .idea
 .php-cs-fixer.cache
 build/code-coverage/
+build/.phpunit.cache/
 build/.phpunit.result.cache
 composer.lock
 example/chunks/

--- a/example/ExampleMiddleware.php
+++ b/example/ExampleMiddleware.php
@@ -14,9 +14,15 @@ use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
 use RuntimeException;
 
-class ExampleMiddleware implements MiddlewareInterface
+final readonly class ExampleMiddleware implements MiddlewareInterface
 {
-    public function __construct(protected ResponseFactoryInterface $responseFactory, protected StreamFactoryInterface $streamFactory, protected string $uploadDirectory, protected string $chunkDirectory, protected string $storageDirectory) {}
+    public function __construct(
+        private ResponseFactoryInterface $responseFactory,
+        private StreamFactoryInterface $streamFactory,
+        private string $uploadDirectory,
+        private string $chunkDirectory,
+        private string $storageDirectory,
+    ) {}
 
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {

--- a/src/Events/TusEvent.php
+++ b/src/Events/TusEvent.php
@@ -6,7 +6,6 @@ namespace SpazzMarticus\Tus\Events;
 
 use Psr\EventDispatcher\StoppableEventInterface;
 use Ramsey\Uuid\UuidInterface;
-use SplFileInfo;
 
 abstract class TusEvent implements StoppableEventInterface
 {
@@ -15,14 +14,18 @@ abstract class TusEvent implements StoppableEventInterface
     /**
      * @param array<string, mixed> $metadata
      */
-    public function __construct(protected UuidInterface $uuid, protected SplFileInfo $file, protected array $metadata) {}
+    public function __construct(
+        private readonly UuidInterface $uuid,
+        private readonly string $file,
+        private readonly array $metadata,
+    ) {}
 
     public function getUuid(): UuidInterface
     {
         return $this->uuid;
     }
 
-    public function getFile(): SplFileInfo
+    public function getFile(): string
     {
         return $this->file;
     }

--- a/src/Factories/FilenameFactoryInterface.php
+++ b/src/Factories/FilenameFactoryInterface.php
@@ -5,12 +5,11 @@ declare(strict_types=1);
 namespace SpazzMarticus\Tus\Factories;
 
 use Ramsey\Uuid\UuidInterface;
-use SplFileInfo;
 
 interface FilenameFactoryInterface
 {
     /**
      * @param array<string, mixed> $metadata
      */
-    public function generateFilename(UuidInterface $uuid, array $metadata): SplFileInfo;
+    public function generateFilename(UuidInterface $uuid, array $metadata): string;
 }

--- a/src/Factories/OriginalFilenameFactory.php
+++ b/src/Factories/OriginalFilenameFactory.php
@@ -5,13 +5,14 @@ declare(strict_types=1);
 namespace SpazzMarticus\Tus\Factories;
 
 use Ramsey\Uuid\UuidInterface;
-use SplFileInfo;
 
-final class OriginalFilenameFactory implements FilenameFactoryInterface
+final readonly class OriginalFilenameFactory implements FilenameFactoryInterface
 {
-    public function __construct(protected string $directory) {}
+    public function __construct(
+        private string $directory,
+    ) {}
 
-    public function generateFilename(UuidInterface $uuid, array $metadata): SplFileInfo
+    public function generateFilename(UuidInterface $uuid, array $metadata): string
     {
         $filename = $metadata['name'] ?? $metadata['filename'] ?? null;
 
@@ -22,6 +23,6 @@ final class OriginalFilenameFactory implements FilenameFactoryInterface
             $filename = $uuid->getHex();
         }
 
-        return new SplFileInfo($this->directory . $filename);
+        return $this->directory . $filename;
     }
 }

--- a/src/Factories/UuidFilenameFactory.php
+++ b/src/Factories/UuidFilenameFactory.php
@@ -5,14 +5,15 @@ declare(strict_types=1);
 namespace SpazzMarticus\Tus\Factories;
 
 use Ramsey\Uuid\UuidInterface;
-use SplFileInfo;
 
-final class UuidFilenameFactory implements FilenameFactoryInterface
+final readonly class UuidFilenameFactory implements FilenameFactoryInterface
 {
-    public function __construct(protected string $directory) {}
+    public function __construct(
+        private string $directory,
+    ) {}
 
-    public function generateFilename(UuidInterface $uuid, array $metadata): SplFileInfo
+    public function generateFilename(UuidInterface $uuid, array $metadata): string
     {
-        return new SplFileInfo($this->directory . $uuid->getHex());
+        return $this->directory . $uuid->getHex();
     }
 }

--- a/src/Services/FileServiceInterface.php
+++ b/src/Services/FileServiceInterface.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SpazzMarticus\Tus\Services;
+
+use Psr\Http\Message\StreamInterface;
+
+interface FileServiceInterface
+{
+    public function setChunkSize(int $chunkSize): void;
+
+    public function create(string $filePath): void;
+
+    public function exists(string $filePath): bool;
+
+    public function size(string $filePath): int;
+
+    public function delete(string $filePath): void;
+
+    /**
+     * @return resource
+     */
+    public function open(string $filePath);
+
+    /**
+     * @param resource $handle
+     */
+    public function point($handle, int $offset): void;
+
+    /**
+     * @param resource $handle
+     */
+    public function copyFromStream($handle, StreamInterface $stream, ?int $sizeLimit = null): int;
+}

--- a/tests/phpunit/unit/Factories/OriginalFilenameFactoryTest.php
+++ b/tests/phpunit/unit/Factories/OriginalFilenameFactoryTest.php
@@ -6,7 +6,6 @@ namespace SpazzMarticus\Tus\Factories;
 
 use PHPUnit\Framework\Attributes\DataProvider;
 use Ramsey\Uuid\Uuid;
-use SplFileInfo;
 
 final class OriginalFilenameFactoryTest extends AbstractFilenameFactoryTestCase
 {
@@ -25,7 +24,7 @@ final class OriginalFilenameFactoryTest extends AbstractFilenameFactoryTestCase
     #[DataProvider('providerGenerateFilename')]
     public function testGenerateFilename(string $expectedFilename, array $metadata): void
     {
-        $expectedFilename = new SplFileInfo(sprintf('%s/%s', $this->directory, $expectedFilename));
+        $expectedFilename = $this->directory . $expectedFilename;
 
         self::assertEquals($expectedFilename, $this->factory->generateFilename($this->uuid, $metadata));
     }
@@ -64,7 +63,7 @@ final class OriginalFilenameFactoryTest extends AbstractFilenameFactoryTestCase
     {
         file_put_contents($this->directory . 'alreadyUploaded.bin', 'payload');
 
-        $expectedFilename = new SplFileInfo($this->directory . $this->uuid->getHex());
+        $expectedFilename = $this->directory . $this->uuid->getHex();
 
         self::assertEquals($expectedFilename, $this->factory->generateFilename($this->uuid, [
             'name' => 'alreadyUploaded.bin',

--- a/tests/phpunit/unit/Factories/UuidFilenameFactoryTest.php
+++ b/tests/phpunit/unit/Factories/UuidFilenameFactoryTest.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace SpazzMarticus\Tus\Factories;
 
-use SplFileInfo;
-
 final class UuidFilenameFactoryTest extends AbstractFilenameFactoryTestCase
 {
     private UuidFilenameFactory $factory;
@@ -20,7 +18,7 @@ final class UuidFilenameFactoryTest extends AbstractFilenameFactoryTestCase
     {
         $metadata = [];
 
-        $expectedFilename = new SplFileInfo($this->directory . $this->uuid->getHex());
+        $expectedFilename = $this->directory . $this->uuid->getHex();
 
         self::assertEquals($expectedFilename, $this->factory->generateFilename($this->uuid, $metadata));
     }


### PR DESCRIPTION
Hi!

Wanted to get your thoughts on this :)

I'm currently running one instance of my app, and everything works great. But now I would like to run more, and I'm hitting the issue where the file is always written to the local disk. So If you start the upload on instance 1, and you continue on instance 2, the [exists](https://github.com/SpazzMarticus/TusServer/blob/master/src/Services/FileService.php#L42) check returns `false`.

If you would create an interface for the [FileService](https://github.com/SpazzMarticus/TusServer/blob/master/src/Services/FileService.php#L12), you could decorate that and everyone could provide their own implementation.

However, for abstracting the filesystem I am using [flysytem](https://github.com/thephpleague/flysystem), which does not work with `SplFileInfo` but with streams. So I changed your default implementation by utilizing streams as well.

This PR is not finished. I still need to test if this actually works, also when using multiple instances of my app. And there are still a lot of places in code which use the `Spl` classes, e.g. the Events.

WDYT?